### PR TITLE
Amending minor typos

### DIFF
--- a/highdim/latent-factor-models.qmd
+++ b/highdim/latent-factor-models.qmd
@@ -286,18 +286,7 @@ This analysis provides insights into the process of generating our data since $\
 
 Note that the approach also provides compression since the $120 \times 6 = 720$ observations can be well approximated by a matrix multiplication of a $120 \times 2$ matrix $\mathbf{P}$ and a $6 \times 2$ matrix $\mathbf{Q}$, a total of $252$ parameters. 
 
-In our example with simulated data, we deduced the factors $\mathbf{q}_1$ and $\mathbf{q}_2$ from the sample correlation and our knowledge of movies. These ended up working well. H
-
-
-
-
-
-
-
-
-
-
-owever, in general, deducing factors is not this easy. Furthermore, factors that provide good approximation might be more complicated than containing just two values. For example, _The Godfather III_ has a romantic subplot, so we might not know what value to assign it in $q_1$. 
+In our example with simulated data, we deduced the factors $\mathbf{q}_1$ and $\mathbf{q}_2$ from the sample correlation and our knowledge of movies. These ended up working well. However, in general, deducing factors is not this easy. Furthermore, factors that provide good approximation might be more complicated than containing just two values. For example, _The Godfather III_ has a romantic subplot, so we might not know what value to assign it in $q_1$. 
 
 So, can we estimate the factors? A challenge is that if $\mathbf{P}$ is unknown, our model is no longer linear: we can't use `lm` to estimate both $\mathbf{P}$ and $\mathbf{Q}$. In the next sections, we describe how PCA can be used to estimate $\mathbf{P}$ and $\mathbf{Q}$.
 

--- a/linear-models/treatment-effect-models.qmd
+++ b/linear-models/treatment-effect-models.qmd
@@ -214,7 +214,7 @@ In R, we can specify the linear model above using the following:
 fit <- lm(body_weight ~ diet*sex, data = mice_weights)
 ```
 
-Here, the `*` denotes _factor crossing_, not multiplication: `diet*sex` is shorthand for `diet+sex+diet:sex`, to include diet, sex, and the diet/sex interaction, respecitvely, in the model.
+Here, the `*` denotes _factor crossing_, not multiplication: `diet*sex` is shorthand for `diet+sex+diet:sex`, to include diet, sex, and the diet/sex interaction, respectively, in the model.
 
 ```{r}
 summary(fit)$coef

--- a/ml/evaluation-metrics.qmd
+++ b/ml/evaluation-metrics.qmd
@@ -413,7 +413,7 @@ From the plot on the left, we immediately see that the precision is low when ran
 
 ## Prevalence matters in practice
 
-A machine learning algorithm with very high TPR and TNR may not be useful in practice when prevalence is close to either 0 or 1. To see this, consider the case or a doctor who specializes in a rare disease and is interested in developing an algorithm for predicting who has the disease. 
+A machine learning algorithm with very high TPR and TNR may not be useful in practice when prevalence is close to either 0 or 1. To see this, consider the case of a doctor who specializes in a rare disease and is interested in developing an algorithm for predicting who has the disease. 
 
 The doctor shares data with about 1/2 cases and 1/2 controls, and some predictors. You then develop an algorithm with TPR=0.99 and TNR = 0.99. You are excited to explain to the doctor that this means that if a patient has the disease, the algorithm is very likely to predict correctly. The doctor is not impressed and explains that your TNR is too low for this algorithm to be used in practice. 
 


### PR DESCRIPTION
@rafalab I have fixed a couple of very minor typos that I noticed:

- Corrected a typo in the explanation of a machine learning algorithm's utility in practice, changing 'case or a doctor' to 'case of a doctor'.
- Correctly a minor misspelling of "respectively" in Ch17
- Removed additional space in the word "However" in Ch25